### PR TITLE
Add error handling for connect exceptions

### DIFF
--- a/lib/Uphold/Exception/ConnectException.php
+++ b/lib/Uphold/Exception/ConnectException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Uphold\Exception;
+
+use Uphold\Exception\UpholdClientException;
+
+/**
+ * ConnectException.
+ */
+class ConnectException extends UpholdClientException
+{
+}

--- a/lib/Uphold/HttpClient/Handler/ErrorHandler.php
+++ b/lib/Uphold/HttpClient/Handler/ErrorHandler.php
@@ -2,15 +2,17 @@
 
 namespace Uphold\HttpClient\Handler;
 
+use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
+use GuzzleHttp\Exception\RequestException;
 use Uphold\Exception\ApiLimitExceedException;
 use Uphold\Exception\AuthenticationRequiredException;
 use Uphold\Exception\BadRequestException;
+use Uphold\Exception\ConnectException;
 use Uphold\Exception\LogicException;
 use Uphold\Exception\NotFoundException;
 use Uphold\Exception\RuntimeException;
 use Uphold\Exception\TwoFactorAuthenticationRequiredException;
 use Uphold\HttpClient\Message\Response;
-use GuzzleHttp\Exception\RequestException;
 
 /**
  * ErrorHandler.
@@ -43,6 +45,10 @@ class ErrorHandler
      */
     public function onException(\Exception $e)
     {
+        if ($e instanceOf GuzzleConnectException) {
+            throw new ConnectException($e->getMessage());
+        }
+
         if ($e instanceOf RequestException) {
             return $this->onRequestException($e);
         }

--- a/test/Uphold/Tests/Unit/HttpClient/Handler/ErrorHandlerTest.php
+++ b/test/Uphold/Tests/Unit/HttpClient/Handler/ErrorHandlerTest.php
@@ -2,11 +2,12 @@
 
 namespace Uphold\Tests\Unit\HttpClient\Handler;
 
+use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
+use GuzzleHttp\Exception\RequestException;
+use Seegno\TestBundle\TestCase\BaseTestCase;
 use Uphold\Exception\RuntimeException;
 use Uphold\HttpClient\Handler\ErrorHandler;
 use Uphold\HttpClient\Message\Response;
-use GuzzleHttp\Exception\RequestException;
-use Seegno\TestBundle\TestCase\BaseTestCase;
 
 /**
  * ErrorHandlerTest.
@@ -39,6 +40,19 @@ class ErrorHandlerTest extends BaseTestCase
             ->method('onRequestException')
             ->with($exception);
 
+        $errorHandler->onException($exception);
+    }
+
+    /**
+     * @test
+     * @expectedException Uphold\Exception\ConnectException
+     */
+    public function shouldThrowConnectExceptionWhenAGuzzleConnectExceptionIsGiven()
+    {
+        $request = $this->getRequestMock();
+        $exception = new GuzzleConnectException('Could not resolve host: foobar.com', $request);
+
+        $errorHandler = new ErrorHandler();
         $errorHandler->onException($exception);
     }
 


### PR DESCRIPTION
This PR adds error handling of guzzle connect exceptions. For instance, when the host could not be resolved.