### PR TITLE
Add empty responses handling

### DIFF
--- a/lib/Uphold/HttpClient/Handler/ErrorHandler.php
+++ b/lib/Uphold/HttpClient/Handler/ErrorHandler.php
@@ -71,6 +71,11 @@ class ErrorHandler
     {
         $request = $e->getRequest();
         $response = $e->getResponse();
+
+        if (!$response) {
+            throw new RuntimeException($e->getMessage(), $e->getCode());
+        }
+
         $statusCode = $response->getStatusCode();
 
         $isClientError = $response->isClientError();

--- a/test/Uphold/Tests/Unit/HttpClient/Handler/ErrorHandlerTest.php
+++ b/test/Uphold/Tests/Unit/HttpClient/Handler/ErrorHandlerTest.php
@@ -88,6 +88,19 @@ class ErrorHandlerTest extends BaseTestCase
 
     /**
      * @test
+     * @expectedException Uphold\Exception\RuntimeException
+     * @expectedExceptionMessage foobar
+     */
+    public function shouldThrowRuntimeExceptionWhenARequestExceptionReceivesAnEmptyResponse()
+    {
+        $request = $this->getRequestMock();
+
+        $errorHandler = new ErrorHandler();
+        $errorHandler->onException(new RequestException('foobar', $request, null));
+    }
+
+    /**
+     * @test
      * @expectedException Uphold\Exception\BadRequestException
      */
     public function shouldThrowBadRequestExceptionWhenStatusCodeIs400()


### PR DESCRIPTION
This adds handling for empty responses on a `RequestException` by throwing a `RuntimeException` with the `RequestException` message and code.