### PR TITLE
Improve Paginator tests

### DIFF
--- a/lib/Uphold/Exception/UpholdClientException.php
+++ b/lib/Uphold/Exception/UpholdClientException.php
@@ -45,7 +45,8 @@ class UpholdClientException extends \Exception
     /**
      * Constructor.
      *
-     * @param string $message  Exception message
+     * @param string $message  Exception message.
+     * @param string $error  Exception error.
      * @param string $httpCode Http error code.
      * @param mixed  $response The response.
      * @param mixed  $request  The request.

--- a/lib/Uphold/Paginator/Paginator.php
+++ b/lib/Uphold/Paginator/Paginator.php
@@ -2,6 +2,8 @@
 
 namespace Uphold\Paginator;
 
+use Uphold\Exception\UpholdClientException;
+
 /**
  * Paginator.
  */
@@ -122,7 +124,7 @@ class Paginator
             $this->count = $contentRange['count'];
 
             return $this->count;
-        } catch (UpholdException $e) {
+        } catch (UpholdClientException $e) {
             if (412 === $e->getHttpCode() || 416 === $e->getHttpCode()) {
                 return 0;
             }
@@ -152,7 +154,7 @@ class Paginator
             $this->offset = $contentRange['end'] + 1;
 
             return $this->hydrate($response->getContent());
-        } catch (UpholdException $e) {
+        } catch (UpholdClientException $e) {
             if (412 === $e->getHttpCode() || 416 === $e->getHttpCode()) {
                 return $this->hydrate(array());
             }


### PR DESCRIPTION
This PR adds missing unit tests to the `Paginator` class. Also, it fixes the name of the `UpholdClientExtension` when handling pager errors.