### PR TITLE
Improve HttpClient

### DIFF
--- a/lib/Uphold/HttpClient/HttpClient.php
+++ b/lib/Uphold/HttpClient/HttpClient.php
@@ -25,14 +25,7 @@ class HttpClient implements HttpClientInterface
      *
      * @var ErrorHandler
      */
-    private $errorHandler;
-
-    /**
-     * Request headers.
-     *
-     * @var array
-     */
-    protected $headers = array();
+    protected $errorHandler;
 
     /**
      * @var $options
@@ -61,14 +54,6 @@ class HttpClient implements HttpClientInterface
     public function getOption($name)
     {
         return $this->options[$name];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setHeaders(array $headers)
-    {
-        $this->headers = array_merge($this->headers, $headers);
     }
 
     /**

--- a/lib/Uphold/HttpClient/HttpClientInterface.php
+++ b/lib/Uphold/HttpClient/HttpClientInterface.php
@@ -44,9 +44,4 @@ interface HttpClientInterface
      * Change an option value.
      */
     public function setOption($name, $value);
-
-    /**
-     * Set HTTP headers.
-     */
-    public function setHeaders(array $headers);
 }

--- a/test/Uphold/Tests/Unit/HttpClient/HttpClientTest.php
+++ b/test/Uphold/Tests/Unit/HttpClient/HttpClientTest.php
@@ -215,6 +215,34 @@ class HttpClientTest extends BaseTestCase
 
     /**
      * @test
+     */
+    public function shouldUseDebugOptionIfIsDefined()
+    {
+        $body = array('a' => 'b');
+        $options = array('body' => $body, 'debug' => 'qux');
+        $path = '/some/path';
+
+        $request = new Request('GET', $path);
+
+        $client = $this->getClientMock();
+
+        $client
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', $path, $options)
+            ->will($this->returnValue($request))
+        ;
+
+        $httpClient = $this->getHttpClientMock(array('createRequest'));
+        $httpClient->setOption('debug', 'qux');
+
+        $this->setReflectionProperty($httpClient, 'client', $client);
+
+        $httpClient->request($path, $body);
+    }
+
+    /**
+     * @test
      * @expectedException Uphold\Exception\LogicException
      */
     public function shouldThrowLogicExceptionWhenClientSendThrownsLogicException()


### PR DESCRIPTION
This PR improves `HttpClient` by removing unused method `setHeaders` and improving unit tests.