### PR TITLE
Fix handling of response errors

### DIFF
--- a/lib/Uphold/HttpClient/Message/Response.php
+++ b/lib/Uphold/HttpClient/Message/Response.php
@@ -101,7 +101,8 @@ class Response extends BaseResponse
         }
 
         if (!empty($content['errors'])) {
-            return sprintf('Error List: %s', implode(',', $content['errors']));
+            // We need to use `json_encode` since there can be a multidimensional array.
+            return sprintf('Errors: %s', json_encode($content['errors']));
         }
 
         if (!empty($content['error_description'])) {

--- a/test/Uphold/Tests/Unit/HttpClient/Message/ResponseTest.php
+++ b/test/Uphold/Tests/Unit/HttpClient/Message/ResponseTest.php
@@ -156,15 +156,17 @@ class ResponseTest extends BaseTestCase
      */
     public function shouldReturnContentErrorsIfIsNotEmpty()
     {
+        $errors =  array('foo' => 'bar', 'baderous' => array('qux'));
+
         $response = $this->getResponseMock(array('getContent'));
 
         $response
             ->expects($this->any())
             ->method('getContent')
-            ->willReturn(array('errors' => array('foo', 'bar')))
+            ->willReturn(array('errors' => $errors))
         ;
 
-        $expected = sprintf('Error List: %s', implode(',', array('foo', 'bar')));
+        $expected = sprintf('Errors: %s', json_encode($errors));
 
         $this->assertEquals($expected, $response->getErrorDescription());
     }


### PR DESCRIPTION
This fixes the handling of response errors when `errors` is a multidimensional array.