### PR TITLE
Add message option to Card.createTransaction

### DIFF
--- a/examples/Transaction.php
+++ b/examples/Transaction.php
@@ -39,7 +39,7 @@ echo "\n*** Create and commit a new transaction ***\n";
 $card = $user->getCardById('ade869d8-7913-4f67-bb4d-72719f0a2be0');
 
 // Create a new transaction.
-$transaction = $card->createTransaction('foo@bar.com', '0.001', 'BTC');
+$transaction = $card->createTransaction('foo@bar.com', '0.001', 'BTC', 'A custom message');
 
 // Commit the transaction
 $transaction->commit();

--- a/lib/Uphold/Model/Card.php
+++ b/lib/Uphold/Model/Card.php
@@ -173,14 +173,16 @@ class Card extends BaseModel implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function createTransaction($destination, $amount, $currency)
+    public function createTransaction($destination, $amount, $currency, $message = null)
     {
         $postData = array(
             'destination' => $destination,
             'denomination' => array(
                 'amount' => $amount,
                 'currency' => $currency,
-        ));
+            ),
+            'message' => $message,
+        );
 
         $response = $this->client->post(sprintf('/me/cards/%s/transactions', $this->id), $postData);
 

--- a/test/Uphold/Tests/Unit/Model/CardTest.php
+++ b/test/Uphold/Tests/Unit/Model/CardTest.php
@@ -239,7 +239,9 @@ class CardTest extends ModelTestCase
             'denomination' => array(
                 'amount' => $this->getFaker()->randomFloat,
                 'currency' => $this->getFaker()->currencyCode,
-        ));
+            ),
+            'message' => null,
+        );
 
         $data = array(
             'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
@@ -260,6 +262,51 @@ class CardTest extends ModelTestCase
         $card = new Card($client, $cardData);
 
         $transaction = $card->createTransaction($postData['destination'], $postData['denomination']['amount'], $postData['denomination']['currency']);
+
+        $this->assertInstanceOf('Uphold\Model\Transaction', $transaction);
+        $this->assertEquals($data['id'], $transaction->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateNewTransactionWithCustomMessage()
+    {
+        $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
+
+        $postData = array(
+            'destination' => $this->getFaker()->email,
+            'denomination' => array(
+                'amount' => $this->getFaker()->randomFloat,
+                'currency' => $this->getFaker()->currencyCode,
+            ),
+            'message' => 'foobar',
+        );
+
+        $data = array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+            'status' => 'pending',
+        );
+
+        $response = $this->getResponseMock($data);
+
+        $client = $this->getUpholdClientMock();
+
+        $client
+            ->expects($this->once())
+            ->method('post')
+            ->with(sprintf('/me/cards/%s/transactions', $cardData['id']), $postData)
+            ->will($this->returnValue($response))
+        ;
+
+        $card = new Card($client, $cardData);
+
+        $transaction = $card->createTransaction(
+            $postData['destination'],
+            $postData['denomination']['amount'],
+            $postData['denomination']['currency'],
+            $postData['message']
+        );
 
         $this->assertInstanceOf('Uphold\Model\Transaction', $transaction);
         $this->assertEquals($data['id'], $transaction->getId());


### PR DESCRIPTION
This adds message option to the `Card.createTransaction` method allowing to create a new transaction with a custom message.