### PR TITLE
Add commit option to createTransaction

### DIFF
--- a/examples/Transaction.php
+++ b/examples/Transaction.php
@@ -41,7 +41,17 @@ $card = $user->getCardById('ade869d8-7913-4f67-bb4d-72719f0a2be0');
 // Create a new transaction.
 $transaction = $card->createTransaction('foo@bar.com', '0.001', 'BTC', 'A custom message');
 
-// Commit the transaction
+// Commit the transaction.
 $transaction->commit();
+
+print_r($transaction->toArray());
+
+echo "\n*** Create and commit a new transaction in a single request ***\n";
+
+// Get a user card.
+$card = $user->getCardById('ade869d8-7913-4f67-bb4d-72719f0a2be0');
+
+// Create and commit a new transaction.
+$transaction = $card->createTransaction('foo@bar.com', '0.001', 'BTC', 'A custom message', true);
 
 print_r($transaction->toArray());

--- a/lib/Uphold/Model/Card.php
+++ b/lib/Uphold/Model/Card.php
@@ -173,7 +173,7 @@ class Card extends BaseModel implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function createTransaction($destination, $amount, $currency, $message = null)
+    public function createTransaction($destination, $amount, $currency, $message = null, $commit = false)
     {
         $postData = array(
             'destination' => $destination,
@@ -184,7 +184,7 @@ class Card extends BaseModel implements CardInterface
             'message' => $message,
         );
 
-        $response = $this->client->post(sprintf('/me/cards/%s/transactions', $this->id), $postData);
+        $response = $this->client->post(sprintf('/me/cards/%s/transactions?commit=%s', $this->id, $commit), $postData);
 
         $transaction = new Transaction($this->client, $response->getContent());
 

--- a/test/Uphold/Tests/Unit/Model/CardTest.php
+++ b/test/Uphold/Tests/Unit/Model/CardTest.php
@@ -255,7 +255,7 @@ class CardTest extends ModelTestCase
         $client
             ->expects($this->once())
             ->method('post')
-            ->with(sprintf('/me/cards/%s/transactions', $cardData['id']), $postData)
+            ->with(sprintf('/me/cards/%s/transactions?commit=', $cardData['id']), $postData)
             ->will($this->returnValue($response))
         ;
 
@@ -295,7 +295,7 @@ class CardTest extends ModelTestCase
         $client
             ->expects($this->once())
             ->method('post')
-            ->with(sprintf('/me/cards/%s/transactions', $cardData['id']), $postData)
+            ->with(sprintf('/me/cards/%s/transactions?commit=', $cardData['id']), $postData)
             ->will($this->returnValue($response))
         ;
 
@@ -306,6 +306,52 @@ class CardTest extends ModelTestCase
             $postData['denomination']['amount'],
             $postData['denomination']['currency'],
             $postData['message']
+        );
+
+        $this->assertInstanceOf('Uphold\Model\Transaction', $transaction);
+        $this->assertEquals($data['id'], $transaction->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateNewTransactionWithCommitParameter()
+    {
+        $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
+
+        $postData = array(
+            'destination' => $this->getFaker()->email,
+            'denomination' => array(
+                'amount' => $this->getFaker()->randomFloat,
+                'currency' => $this->getFaker()->currencyCode,
+            ),
+            'message' => 'foobar',
+        );
+
+        $data = array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+            'status' => 'pending',
+        );
+
+        $response = $this->getResponseMock($data);
+
+        $client = $this->getUpholdClientMock();
+
+        $client
+            ->expects($this->once())
+            ->method('post')
+            ->with(sprintf('/me/cards/%s/transactions?commit=1', $cardData['id']), $postData)
+            ->will($this->returnValue($response))
+        ;
+
+        $card = new Card($client, $cardData);
+
+        $transaction = $card->createTransaction(
+            $postData['destination'],
+            $postData['denomination']['amount'],
+            $postData['denomination']['currency'],
+            $postData['message'],
+            true
         );
 
         $this->assertInstanceOf('Uphold\Model\Transaction', $transaction);


### PR DESCRIPTION
This adds the functionality to create and commit a transaction in a single request.