### PR TITLE
Add create crypto address to card model

### DIFF
--- a/examples/Card.php
+++ b/examples/Card.php
@@ -18,10 +18,12 @@ echo "*** List of user cards ***\n";
 foreach ($cards as $card) {
     echo sprintf("Label: %s\n", $card->getLabel());
     echo sprintf("Id: %s\n", $card->getId());
-    echo sprintf("Bitcoin Address: %s\n", $card->getAddress()['bitcoin']);
+    echo sprintf("Wire Address: %s\n", $card->getAddress()['wire']);
     echo sprintf("Balance: %s\n", $card->getBalance());
     echo "\n";
 }
 
 // Get card by address.
 $card = $user->getCardByAddress('1GpBtJXXa1NdG94cYPGZTc3DfRY2P7EwzH');
+
+$card->createCryptoAddress('bitcoin');

--- a/lib/Uphold/Model/Card.php
+++ b/lib/Uphold/Model/Card.php
@@ -173,6 +173,18 @@ class Card extends BaseModel implements CardInterface
     /**
      * {@inheritdoc}
      */
+    public function createCryptoAddress($network)
+    {
+        $response = $this->client->post(sprintf('/me/cards/%s/addresses', $this->id), array('network' => $network));
+
+        $this->addAddress($response->getContent());
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function createTransaction($destination, $amount, $currency, $message = null, $commit = false)
     {
         $postData = array(
@@ -199,6 +211,16 @@ class Card extends BaseModel implements CardInterface
         $response = $this->client->patch(sprintf('/me/cards/%s', $this->id), $data);
 
         $this->updateFields($response->getContent());
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function addAddress($address)
+    {
+        $this->addresses[] = $address;
 
         return $this;
     }

--- a/lib/Uphold/Model/CardInterface.php
+++ b/lib/Uphold/Model/CardInterface.php
@@ -78,6 +78,15 @@ interface CardInterface
     public function getTransactions();
 
     /**
+     * Creates a new crypto address for the card.
+     *
+     * @param string $network The type of crypto address. Possible values are: bitcoin, ethereum, litecoin or voxel.
+     *
+     * @return Card
+     */
+    public function createCryptoAddress($network);
+
+    /**
      * Creates a new transaction.
      *
      * @param string $destination Email or bitcoin address.

--- a/test/Uphold/Tests/Unit/Model/CardTest.php
+++ b/test/Uphold/Tests/Unit/Model/CardTest.php
@@ -230,6 +230,36 @@ class CardTest extends ModelTestCase
     /**
      * @test
      */
+    public function shouldCreateNewCryptoAddress()
+    {
+        $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
+
+        $data = array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+            'network' => 'foobar',
+        );
+
+        $postData = array('network' => 'foobar');
+
+        $response = $this->getResponseMock($data);
+        $client = $this->getUpholdClientMock();
+
+        $client
+            ->expects($this->once())
+            ->method('post')
+            ->with(sprintf('/me/cards/%s/addresses', $cardData['id']), $postData)
+            ->will($this->returnValue($response))
+        ;
+
+        $card = new Card($client, $cardData);
+        $card->createCryptoAddress('foobar');
+
+        $this->assertEquals($card->getAddresses(), array($data));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateNewTransaction()
     {
         $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');


### PR DESCRIPTION
Uphold API has introduced a (breaking change)[https://uphold.com/en/developer/blog/posts/api-changes/breaking-change-regarding-crypto-addresses-on-uphold-cards] by not adding automatically a crypto address to a new card. This now must be done manually. 

This PR adds `createCryptoAddress` method to Card model and updates it's tests and examples. It also adds `addAddress` private method so that we can add a new address to the addresses list.