### PR TITLE
Add Sandbox option

### DIFF
--- a/examples/Account.php
+++ b/examples/Account.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get user.
 $user = $client->getUser('AUTHORIZATION_TOKEN');

--- a/examples/Card.php
+++ b/examples/Card.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get user.
 $user = $client->getUser('AUTHORIZATION_TOKEN');

--- a/examples/Reserve.php
+++ b/examples/Reserve.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use \Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get the reserve summary of all the obligations and assets within it (public endpoint).
 $statistics = $client->getReserve()->getStatistics();

--- a/examples/Ticker.php
+++ b/examples/Ticker.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get rates (public endpoint).
 $rates = $client->getRates();

--- a/examples/Transaction.php
+++ b/examples/Transaction.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get user.
 $user = $client->getUser('AUTHORIZATION_TOKEN');

--- a/examples/User.php
+++ b/examples/User.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use Uphold\UpholdClient as Client;
 
 // Initialize the client.
-$client = new Client();
+$client = new Client(array('sandbox' => true));
 
 // Get user.
 $user = $client->getUser('AUTHORIZATION_TOKEN');

--- a/lib/Uphold/Command/CreateTokenCommand.php
+++ b/lib/Uphold/Command/CreateTokenCommand.php
@@ -2,15 +2,16 @@
 
 namespace Uphold\Command;
 
-use Uphold\UpholdClient;
-use Uphold\Exception\AuthenticationRequiredException;
-use Uphold\Exception\BadRequestException;
-use Uphold\Exception\TwoFactorAuthenticationRequiredException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Uphold\Exception\AuthenticationRequiredException;
+use Uphold\Exception\BadRequestException;
+use Uphold\Exception\TwoFactorAuthenticationRequiredException;
+use Uphold\UpholdClient;
 
 /**
  * Command to create a new Personal Access Token
@@ -22,8 +23,16 @@ class CreateTokenCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('tokens:create')
-            ->setDescription('Create a new Personal Access Token');
+        $this
+            ->setName('tokens:create')
+            ->setDescription('Create a new Personal Access Token')
+            ->addOption(
+               'sandbox',
+               null,
+               InputOption::VALUE_NONE,
+               'If set, the request will be made to Uphold\'s sandbox API'
+            )
+        ;
     }
 
     /**
@@ -40,7 +49,7 @@ class CreateTokenCommand extends Command
         $this->output = $output;
 
         // Uphold client.
-        $this->client = new UpholdClient();
+        $this->client = new UpholdClient(array('sandbox' => $input->getOption('sandbox')));
 
         // Input variables.
         $this->description = null;

--- a/lib/Uphold/UpholdClient.php
+++ b/lib/Uphold/UpholdClient.php
@@ -18,6 +18,12 @@ use Uphold\Model\User;
 class UpholdClient
 {
     /**
+     * Uphold API urls.
+     */
+    const UPHOLD_API_URL = 'https://api.uphold.com';
+    const UPHOLD_SANDBOX_API_URL = 'https://api-sandbox.uphold.com';
+
+    /**
      * Guzzle instance used to communicate with Uphold.
      *
      * @var HttpClient
@@ -36,8 +42,8 @@ class UpholdClient
      */
     private $options = array(
         'api_version' => 'v0',
-        'base_url' => 'https://api.uphold.com/',
         'debug' => false,
+        'sandbox' => false,
         'timeout' => 10,
         'user_agent' => 'uphold-sdk-php {version} (https://github.com/seegno/uphold-sdk-php)',
         'version' => '4.2.0',
@@ -50,6 +56,10 @@ class UpholdClient
      */
     public function __construct(array $options = array())
     {
+        if (!isset($options['base_url'])) {
+            $options['base_url'] = isset($options['sandbox']) && $options['sandbox'] ? self::UPHOLD_SANDBOX_API_URL : self::UPHOLD_API_URL;
+        }
+
         $this->options = array_merge($this->options, $options);
 
         $this->setHttpClient(new HttpClient($this->options));

--- a/test/Uphold/Tests/Functional/ReserveTest.php
+++ b/test/Uphold/Tests/Functional/ReserveTest.php
@@ -28,7 +28,7 @@ class ReserveTest extends TestCase
      */
     public function shouldReturnOneTransactions()
     {
-        $exampleTransactionId = '66fc2a0d-a933-45f0-ba27-8cf12870fcce';
+        $exampleTransactionId = 'af3ef9a7-9262-4022-b376-7b4d928f7206';
 
         $transaction = $this->client->getReserve()->getTransactionById($exampleTransactionId);
 

--- a/test/Uphold/Tests/Functional/TestCase.php
+++ b/test/Uphold/Tests/Functional/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $client = new UpholdClient();
+        $client = new UpholdClient(array('sandbox' => true));
 
         $this->client = $client;
     }


### PR DESCRIPTION
This PR adds sandbox option allowing to choose which API url will be used on the client requests. It is also possible to provide `base_url` option to override this behaviour.

The sandbox option was added to CreateTokenCommand allowing to create a token in Uphold Sandbox.

This also adds sandbox option as true to the functional tests using the Sandbox API instead of the production one.

All examples were updated with the sandbox option which makes the developers aware of the sandbox option, although it's not mandatory.

Closes #84.