### PR TITLE
Update card.getAddresses method to retrieve from API

### DIFF
--- a/lib/Uphold/Model/Card.php
+++ b/lib/Uphold/Model/Card.php
@@ -26,13 +26,6 @@ class Card extends BaseModel implements CardInterface
     protected $address;
 
     /**
-     * List of card addresses.
-     *
-     * @var array
-     */
-    protected $addresses;
-
-    /**
      * Available amount.
      *
      * @var string
@@ -98,14 +91,6 @@ class Card extends BaseModel implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function getAddresses()
-    {
-        return $this->addresses;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getAvailable()
     {
         return $this->available;
@@ -162,6 +147,14 @@ class Card extends BaseModel implements CardInterface
     /**
      * {@inheritdoc}
      */
+    public function getAddresses()
+    {
+        return $this->client->get(sprintf('/me/cards/%s/addresses', $this->id))->getContent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getTransactions()
     {
         $pager = new Paginator($this->client, sprintf('/me/cards/%s/transactions', $this->id));
@@ -175,9 +168,7 @@ class Card extends BaseModel implements CardInterface
      */
     public function createCryptoAddress($network)
     {
-        $response = $this->client->post(sprintf('/me/cards/%s/addresses', $this->id), array('network' => $network));
-
-        $this->addAddress($response->getContent());
+        $this->client->post(sprintf('/me/cards/%s/addresses', $this->id), array('network' => $network));
 
         return $this;
     }
@@ -211,16 +202,6 @@ class Card extends BaseModel implements CardInterface
         $response = $this->client->patch(sprintf('/me/cards/%s', $this->id), $data);
 
         $this->updateFields($response->getContent());
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    private function addAddress($address)
-    {
-        $this->addresses[] = $address;
 
         return $this;
     }

--- a/lib/Uphold/Model/CardInterface.php
+++ b/lib/Uphold/Model/CardInterface.php
@@ -15,13 +15,6 @@ interface CardInterface
     public function getAddress();
 
     /**
-     * Gets list of card addresses.
-     *
-     * @return $addresses
-     */
-    public function getAddresses();
-
-    /**
      * Checks if the card is currently available.
      *
      * @return $available
@@ -69,6 +62,13 @@ interface CardInterface
      * @return $settings
      */
     public function getSettings();
+
+    /**
+     * Gets list of card addresses.
+     *
+     * @return array
+     */
+    public function getAddresses();
 
     /**
      * Gets the transactions associated with the card identified by the user.

--- a/test/Uphold/Tests/Unit/Model/CardTest.php
+++ b/test/Uphold/Tests/Unit/Model/CardTest.php
@@ -177,13 +177,28 @@ class CardTest extends ModelTestCase
      */
     public function shouldReturnAddresses()
     {
-        $data = array('addresses' => array(array('id' => '1GpBtJXXa1NdG94cYPGZTc3DfRY2P7EwzH', 'network' => 'bitcoin')));
+        $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
+        $data = array(array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+            'status' => 'bitcoin',
+        ), array(
+            'id' => 'b97bb994-6e24-4a89-b653-e0a6d0bcf635',
+            'status' => 'foobar',
+        ));
 
+        $response = $this->getResponseMock($data);
         $client = $this->getUpholdClientMock();
 
-        $card = new Card($client, $data);
+        $client
+            ->expects($this->once())
+            ->method('get')
+            ->with(sprintf('/me/cards/%s/addresses', $cardData['id']))
+            ->will($this->returnValue($response))
+        ;
 
-        $this->assertEquals($data['addresses'], $card->getAddresses());
+        $card = new Card($client, $cardData);
+
+        $this->assertEquals($data, $card->getAddresses());
     }
 
     /**
@@ -253,8 +268,6 @@ class CardTest extends ModelTestCase
 
         $card = new Card($client, $cardData);
         $card->createCryptoAddress('foobar');
-
-        $this->assertEquals($card->getAddresses(), array($data));
     }
 
     /**


### PR DESCRIPTION
This PR updates the `card.getAddresses` method by removing the `$addresses` property from the model which no longer is provided on the `/me/cards/:cardId`.

Now, when the user calls the `card.getAddresses` method a request is made to the Uphold's API which retrieves the card's list of addresses.