### PR TITLE
Add php configuration file for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'xdebug.enable = On' >> /etc/hhvm/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'xdebug.enable = On' >> /etc/hhvm/php.ini; else phpenv config-add travis.php.ini; fi
   - composer self-update
   - composer update --prefer-source
 

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 2048M


### PR DESCRIPTION
This PR adds a php configuration file for travis which increases the php memory limit. This is for machines other than hhvm.
