### PR TITLE
Fix handling of user authorize response

### DIFF
--- a/lib/Uphold/UpholdClient.php
+++ b/lib/Uphold/UpholdClient.php
@@ -302,7 +302,10 @@ class UpholdClient
             array_merge($this->getDefaultHeaders(), $headers)
         );
 
-        return $this->getUser($response->getContent());
+        $content = $response->getContent();
+        $bearerToken = isset($content['access_token']) ? $content['access_token'] : null;
+
+        return $this->getUser($bearerToken);
     }
 
     /**

--- a/test/Uphold/Tests/Unit/UpholdClientTest.php
+++ b/test/Uphold/Tests/Unit/UpholdClientTest.php
@@ -409,7 +409,7 @@ class UpholdClientTest extends BaseTestCase
             'grant_type' => 'authorization_code',
         ));
 
-        $response = $this->getResponseMock('xyzzy');
+        $response = $this->getResponseMock(array('access_token' => 'xyzzy'));
 
         $httpClient = $this->getHttpClientMock();
 


### PR DESCRIPTION
This fixes the handling of the user authorize response by retrieving the access token from the array that is given by the `/oauth2/token` endpoint.