### PR TITLE
Update travis scripts to disable xdebug in composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,15 @@ php:
   - hhvm
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'xdebug.enable = On' >> /etc/hhvm/php.ini; else phpenv config-add travis.php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add travis.php.ini; fi
+  - source travis.sh
+  - xdebug-disable
   - composer self-update
   - composer update --prefer-source
 
-script: vendor/bin/phpunit
+script:
+  - xdebug-enable
+  - vendor/bin/phpunit
 
 after_script:
   - vendor/bin/test-reporter --stdout > codeclimate.json

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+# Disable xdebug.
+function xdebug-disable() {
+  if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then
+    echo 'xdebug.enable = Off' >> /etc/hhvm/php.ini
+  elif [[ -f $config ]]; then
+    mv $config "$config.bak"
+  fi
+}
+
+# Enable xdebug.
+function xdebug-enable() {
+  if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then
+    echo 'xdebug.enable = On' >> /etc/hhvm/php.ini
+  elif [[ -f "$config.bak" ]]; then
+    mv "$config.bak" $config
+  fi
+}


### PR DESCRIPTION
This updates the travis scripts to disable `xdebug` at `composer update`. Running `composer` commands while `xdebug` is loaded [reduces speed considerably](https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer) and it was causing some builds to fail at `Travis`.

`xdebug` is being disabled at before script and enabled at scripts because it's necessary to generate the code coverage report.
 