### PR TITLE
Fix create token description method name

### DIFF
--- a/lib/Uphold/Command/CreateTokenCommand.php
+++ b/lib/Uphold/Command/CreateTokenCommand.php
@@ -64,7 +64,7 @@ class CreateTokenCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Get PAT description.
-        $this->description = $this->getDescription();
+        $this->description = $this->getPATDescription();
 
         // Get user credentials.
         $this->login = $this->getLogin();
@@ -122,13 +122,13 @@ class CreateTokenCommand extends Command
      *
      * @return string
      */
-    public function getDescription()
+    public function getPATDescription()
     {
         $dialog = $this->getHelperSet()->get('dialog');
 
         return $dialog->askAndValidate($this->output, '<question>PAT description: </question> ', function ($value) {
             if (null === $value || '' === $value) {
-                return $this->getDescription();
+                return $this->getPATDescription();
             }
 
             return $value;


### PR DESCRIPTION
This renames the `getDescription` method on the create token command to `getPATDescription` since the `getDescription` method is used by the console to write the command description helper.