### PR TITLE
updating symfony/console to 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~5.1",
-        "symfony/console": "~3.2.8"
+        "symfony/console": "~3.2"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~5.1",
-        "symfony/console": "~2.6"
+        "symfony/console": "~3.2.8"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "~0.1",


### PR DESCRIPTION
Hi there, thanks for writing the Uphold SDK!  I notice that to use the SDK with Laravel 5.5.x it's requiring that I update your libraries requirement for `symfony/console` from `~2.6` to `~3.2.8` (looks like it could be any `~3.0` version, but not tested).  I haven't noticed issues running your client with this later version of `symfony/console` and wonder about getting a pull request moving along to get that console requirement updated.

Any thoughts on your end about doing this?