### PR TITLE
Update symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~5.1",
-        "symfony/console": "~2.6"
+        "symfony/console": "~2.6 || ~3.2"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "~0.1",


### PR DESCRIPTION
This PR updates `symfony/console` that adds compatibility with version `~3.2`.

Closes #152 and #151.